### PR TITLE
Add num of tasks running health validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ A number between 1 and 100. If set, this is the percentage of connectors that mu
 
 By default, **any** failures will cause the healthcheck to fail.
 
+#### Failure Less Tasks
+If `True`, it will validate if the number of running tasks is less them tasks.max for the healthcheck to fail.
+
+| Usage                 | Value                                       |
+|-----------------------|---------------------------------------------|
+| Environment Variable  | `HEALTHCHECK_FAILURE_LESS_TASKS`  |
+| Command-Line Argument | `--failure-less-tasks`            |
+| Default Value         | `True`                                         |
+| Valid Values          | `True` or `False`                                    |
+
+By default, **any** failures will cause the healthcheck to fail.
+
 #### Log Level
 The level of logs to be shown by the application.
 

--- a/kafka_connect_healthcheck/main.py
+++ b/kafka_connect_healthcheck/main.py
@@ -37,7 +37,7 @@ def main():
 
     server_class = HTTPServer
     health_object = health.Health(args.connect_url, args.connect_worker_id, args.unhealthy_states.split(","),
-                                  args.basic_auth, args.failure_threshold_percentage, args.considered_containers.split(","))
+                                  args.basic_auth, args.failure_threshold_percentage, args.considered_containers.split(","), args.failure_less_tasks)
     handler = partial(RequestHandler, health_object)
     httpd = server_class(("0.0.0.0", args.healthcheck_port), handler)
     logging.info("Healthcheck server started at: http://localhost:{}".format(args.healthcheck_port))

--- a/kafka_connect_healthcheck/parser.py
+++ b/kafka_connect_healthcheck/parser.py
@@ -67,6 +67,13 @@ def get_parser():
                         help="A number between 1 and 100. If set, this is the percentage of connectors that must fail for the healthcheck to fail."
                         )
 
+    parser.add_argument("--failure-less-tasks",
+                        default=os.environ.get("HEALTHCHECK_FAILURE_LESS_TASKS", True),
+                        dest="failure_less_tasks",
+                        action='store_true',
+                        help="If set True, will validate if the number of tasks running was less them tasks.max for the healthcheck to fail. Default: True"
+                        )
+
     parser.add_argument("--basic-auth",
                         default=os.environ.get("HEALTHCHECK_BASIC_AUTH", ""),
                         dest="basic_auth",


### PR DESCRIPTION
## Description
In some cases, I've seen that the number of running tasks are under the `tasks.max` configuration number which can leverage partitions to become without any consumer and to avoid this behavior I'm adding validation to the `handle_task_healthcheck` comparing the number of running tasks on the container obtained from `get_connectors_health` with the desired `tasks.max`

This validation is enabled by default but I've added a new param to disable the validation passing `--failure-less-tasks False` or setting `HEALTHCHECK_FAILURE_LESS_TASKS=False`

- Logging samples with `DEBUG` level
```
2021-06-04 00:38:44.293 [   INFO] - Initializing healthcheck server...
2021-06-04 00:38:44.296 [   INFO] - Healthcheck server started at: http://localhost:18083
2021-06-04 00:38:44.296 [   INFO] - ------------------------------------------------
2021-06-04 00:38:45.137 [  DEBUG] - Starting new HTTP connection (1): localhost:8083
2021-06-04 00:38:46.202 [  DEBUG] - http://localhost:8083 "GET /connectors HTTP/1.1" 200 25
2021-06-04 00:38:46.206 [  DEBUG] - Starting new HTTP connection (1): localhost:8083
2021-06-04 00:38:47.071 [  DEBUG] - http://localhost:8083 "GET /connectors/ProtoElasticConnector/status HTTP/1.1" 200 481
2021-06-04 00:38:47.074 [  DEBUG] - Starting new HTTP connection (1): localhost:8083
2021-06-04 00:38:47.918 [  DEBUG] - http://localhost:8083 "GET /connectors/ProtoElasticConnector HTTP/1.1" 200 1472
2021-06-04 00:38:47.919 [   INFO] - Connector 'ProtoElasticConnector' is healthy in state: RUNNING
2021-06-04 00:38:47.919 [  DEBUG] - Connector 'ProtoElasticConnector' state: RUNNING tasks running: '6' desired: '6'
2021-06-04 00:38:47.919 [   INFO] - Connector 'ProtoElasticConnector' task '0' is healthy in state: RUNNING
2021-06-04 00:38:47.919 [   INFO] - Connector 'ProtoElasticConnector' task '1' is healthy in state: RUNNING
2021-06-04 00:38:47.919 [   INFO] - Connector 'ProtoElasticConnector' task '2' is healthy in state: RUNNING
2021-06-04 00:38:47.919 [   INFO] - Connector 'ProtoElasticConnector' task '3' is healthy in state: RUNNING
2021-06-04 00:38:47.919 [   INFO] - Connector 'ProtoElasticConnector' task '4' is healthy in state: RUNNING
2021-06-04 00:38:47.919 [   INFO] - Connector 'ProtoElasticConnector' task '5' is healthy in state: RUNNING
2021-06-04 00:38:47.919 [   INFO] - ------------------------------------------------
```